### PR TITLE
Pull request for changes compatible with Go 1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-include $(GOROOT)/src/Make.$(GOARCH)
-
-TARG=repl
-GOFILES=\
-        main.go
-
-include $(GOROOT)/src/Make.cmd

--- a/main.go
+++ b/main.go
@@ -435,6 +435,12 @@ func main() {
 		if strings.HasPrefix(line, "import") {
 			line = strings.Replace(line, "import", "+", 1)
 		}
+		if line == "help" {
+			line = "?"
+		}
+		if line == "source" {
+			line = "!"
+		}
 		if exec_special(w, line) {
 			continue
 		}
@@ -444,19 +450,24 @@ func main() {
 
 		switch line[0] {
 		case '?':
-			fmt.Println("Commands:")
-			fmt.Println("\t?\thelp")
-			fmt.Println("\timport (pkg) (pkg) ...\timport package")
+			fmt.Println("Symbol Commands:")
+			fmt.Println("\t?                \thelp menu")
 			fmt.Println("\t+ (pkg) (pkg) ...\timport package")
 			fmt.Println("\t- (pkg) (pkg) ...\tremove package")
 			fmt.Println("\t-[dpc][#],[#],...\tpop last/specific (declaration|package|code)")
-			fmt.Println("\t~\treset")
-			fmt.Println("\t: (...)\tadd persistent code")
-			fmt.Println("\t!\tinspect source")
-			fmt.Println("\trun\trun source")
-			fmt.Println("\twrite\twrite source mode on")
-			fmt.Println("\trepl\twrite source mode off")
-			fmt.Println("\tauto\tautosetup with some standard packages")
+			fmt.Println("\t~                \treset")
+			fmt.Println("\t: (...)          \tadd persistent code")
+			fmt.Println("\t!                \tinspect source")
+			
+			fmt.Println("Word Commands:")
+			fmt.Println("\thelp                  \thelp menu")
+			fmt.Println("\timport (pkg) (pkg) ...\timport package")
+			fmt.Println("\tsource                \tinspect source")
+			fmt.Println("\trun                   \trun source")
+			fmt.Println("\twrite                 \twrite source mode on")
+			fmt.Println("\trepl                  \twrite source mode off")
+			fmt.Println("\tauto                  \tautosetup with some standard packages")
+			
 			fmt.Println("For removal, -[dpc] is equivalent to -[dpc]<last index>")
 		case '+':
 			allpkgs := strings.Split(cmd_args, " ")

--- a/main.go
+++ b/main.go
@@ -223,8 +223,15 @@ func main() {
 			fmt.Println("\t: (...)\tadd persistent code")
 			fmt.Println("\t!\tinspect source")
 		case '+':
-			*w.pkgs = append(*w.pkgs,strings.Trim(line[1:]," "))
-			unstable = true
+			allpkgs := strings.Split(strings.Trim(line[1:]," "), " ")
+			fmt.Println("Importing: ")
+			for _, pkg_name := range allpkgs {
+				if pkg_name != "" {
+					*w.pkgs = append(*w.pkgs, pkg_name)
+					fmt.Println(" ", len(*w.pkgs), pkg_name)
+				}
+			}
+			unstable = compile(w).Len() > 0
 		case '-':
 			if len(line) > 1 && line[1] != ' ' {
 				switch line[1] {

--- a/main.go
+++ b/main.go
@@ -352,7 +352,9 @@ func main() {
 				continue
 			}
 
-			*w.code = append(*w.code,tree[0])
+			for _, v := range tree {
+				*w.code = append(*w.code, v)
+			}
 
 			w.unstable = compile(w).Len() > 0
 		default:

--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func ParseDeclList(fset *token.FileSet, filename string, src interface{}) ([]ast
 }
 
 func exec_special(w *World, line string) bool {
-	if line == "auto" {  // For autostarting
+	if line == "auto" {  // For autosetup
 		*w.pkgs = append(*w.pkgs, "fmt")
 		*w.pkgs = append(*w.pkgs, "math")
 		*w.pkgs = append(*w.pkgs, "strings")
@@ -220,6 +220,8 @@ func exec_special(w *World, line string) bool {
 		*w.defs = append(*w.defs, "var __Pi = math.Pi")
 		*w.defs = append(*w.defs, "var __Trim_Nil = strings.Trim(\" \", \" \")")
 		*w.defs = append(*w.defs, "var __Num_Itoa = strconv.Itoa(5)")
+		*w.defs = append(*w.defs, "var print = fmt.Println")
+		*w.defs = append(*w.defs, "var printf = fmt.Printf")
 		w.unstable = compile(w).Len() > 0
 		return true
 	}
@@ -453,7 +455,7 @@ func main() {
 			fmt.Println("\trun\trun source")
 			fmt.Println("\twrite\twrite source mode on")
 			fmt.Println("\trepl\twrite source mode off")
-			fmt.Println("\tauto\tautomatically import standard package")
+			fmt.Println("\tauto\tautosetup with some standard packages")
 			fmt.Println("For removal, -[dpc] is equivalent to -[dpc]<last index>")
 		case '+':
 			allpkgs := strings.Split(strings.Trim(line[1:]," "), " ")

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os/exec"
 	"bufio"
 	"bytes"
@@ -140,7 +141,7 @@ func run() (*bytes.Buffer, *bytes.Buffer) {
 	return outBuf, errBuf
 }
 
-func ParseStmtList(fset *token.FileSet, filename string, src interface{}) ([]ast.Stmt, os.Error) {
+func ParseStmtList(fset *token.FileSet, filename string, src interface{}) ([]ast.Stmt, error) {
 	f, err := parser.ParseFile(fset, filename, src, 0)
 	if err != nil {
 		return nil, err
@@ -148,7 +149,7 @@ func ParseStmtList(fset *token.FileSet, filename string, src interface{}) ([]ast
 	return f.Decls[0].(*ast.FuncDecl).Body.List, nil
 }
 
-func ParseDeclList(fset *token.FileSet, filename string, src interface{}) ([]ast.Decl, os.Error) {
+func ParseDeclList(fset *token.FileSet, filename string, src interface{}) ([]ast.Decl, error) {
 	f, err := parser.ParseFile(fset, filename, src, 0)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -140,6 +140,22 @@ func run() (*bytes.Buffer, *bytes.Buffer) {
 	return outBuf, errBuf
 }
 
+func ParseStmtList(fset *token.FileSet, filename string, src interface{}) ([]ast.Stmt, os.Error) {
+	f, err := parser.ParseFile(fset, filename, src, 0)
+	if err != nil {
+		return nil, err
+	}
+	return f.Decls[0].(*ast.FuncDecl).Body.List, nil
+}
+
+func ParseDeclList(fset *token.FileSet, filename string, src interface{}) ([]ast.Decl, os.Error) {
+	f, err := parser.ParseFile(fset, filename, src, 0)
+	if err != nil {
+		return nil, err
+	}
+	return f.Decls, nil
+}
+
 func main() {
 	fmt.Println("Welcome to the Go REPL!")
 	fmt.Println("Enter '?' for a list of commands.")
@@ -227,7 +243,7 @@ func main() {
 			fmt.Println(w.source())
 		case ':':
 			line = line + ";"
-			tree, err := parser.ParseStmtList(w.files, "go-repl", strings.Trim(line[1:]," "))
+			tree, err := ParseStmtList(w.files, "go-repl", strings.Trim(line[1:]," "))
 			if err != nil {
 				fmt.Println("Parse error:", err)
 				continue
@@ -239,9 +255,9 @@ func main() {
 		default:
 			line = line + ";"
 			var tree interface{}
-			tree, err := parser.ParseStmtList(w.files, "go-repl", line[0:])
+			tree, err := ParseStmtList(w.files, "go-repl", line[0:])
 			if err != nil {
-				tree, err = parser.ParseDeclList(w.files, "go-repl", line[0:])
+				tree, err = ParseDeclList(w.files, "go-repl", line[0:])
 				if err != nil {
 					fmt.Println("Parse error:", err)
 					continue

--- a/main.go
+++ b/main.go
@@ -210,6 +210,19 @@ func ParseDeclList(fset *token.FileSet, filename string, src interface{}) ([]ast
 	return f.Decls, nil
 }
 
+func exec_check_alias(line string) string {
+	if line == "help" {
+		return "?"
+	} else if strings.HasPrefix(line, "import") {
+		return strings.Replace(line, "import", "+", 1)
+	} else if line == "reset" {
+		return "~"
+	} else if line == "source" {
+		return "!"
+	}
+	return line
+}
+
 func exec_special(w *World, line string) bool {
 	if line == "auto" {  // For autosetup
 		*w.pkgs = append(*w.pkgs, "fmt")
@@ -432,15 +445,7 @@ func main() {
 		if len(line) == 0 {
 			continue
 		}
-		if strings.HasPrefix(line, "import") {
-			line = strings.Replace(line, "import", "+", 1)
-		}
-		if line == "help" {
-			line = "?"
-		}
-		if line == "source" {
-			line = "!"
-		}
+		line = exec_check_alias(line)
 		if exec_special(w, line) {
 			continue
 		}
@@ -462,6 +467,7 @@ func main() {
 			fmt.Println("Word Commands:")
 			fmt.Println("\thelp                  \thelp menu")
 			fmt.Println("\timport (pkg) (pkg) ...\timport package")
+			fmt.Println("\treset                 \treset")
 			fmt.Println("\tsource                \tinspect source")
 			fmt.Println("\trun                   \trun source")
 			fmt.Println("\twrite                 \twrite source mode on")

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"strconv"
 )
 
 type World struct {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"os/exec"
 	"bufio"
 	"bytes"

--- a/main.go
+++ b/main.go
@@ -338,7 +338,7 @@ func main() {
 			w.unstable = compile(w).Len() > 0
 		case '~':
 			*w.pkgs = (*w.pkgs)[:0]
-			*w.defs = (*w.pkgs)[:0]
+			*w.defs = (*w.defs)[:0]
 			*w.code = (*w.code)[:0]
 			w.unstable = false
 			w.write_src_mode = false

--- a/main.go
+++ b/main.go
@@ -314,13 +314,17 @@ func main() {
 		default:
 			line = line + ";"
 			var tree interface{}
-			tree, err := ParseStmtList(w.files, "go-repl", line[0:])
+			tree, err := ParseDeclList(w.files, "go-repl", line[0:])
 			if err != nil {
-				tree, err = ParseDeclList(w.files, "go-repl", line[0:])
+				tree, err = ParseStmtList(w.files, "go-repl", line[0:])
 				if err != nil {
 					fmt.Println("Parse error:", err)
 					continue
+				} else {
+					fmt.Println("CODE: ", line[0:])
 				}
+			} else {
+				fmt.Println("DECL: ", line[0:])
 			}
 
 			changed := false
@@ -354,6 +358,8 @@ func main() {
 				}
 
 				changed = true
+			default:
+				fmt.Println("Fatal error: Unknown tree type.")
 			}
 
 			if err := compile(w); err.Len() > 0 {

--- a/main.go
+++ b/main.go
@@ -253,7 +253,7 @@ func main() {
 	w.code = &[]interface{}{}
 	w.defs = &[]string{}
 	w.files = token.NewFileSet()
-	w.unstable := false
+	w.unstable = false
 	w.write_src_mode = false
 
 	buf := bufio.NewReader(os.Stdin)

--- a/main.go
+++ b/main.go
@@ -35,6 +35,10 @@ var (
 	}[os.Getenv("GOARCH")]
 )
 
+func indentCode(text string, indent string) string {
+	return strings.Join(strings.Split(text, "\n"), "\n"+indent)
+}
+
 func (self *World) source() string {
 	return self.source_print(false)
 }
@@ -62,7 +66,7 @@ func (self *World) source_print(print_linenums bool) string {
 			source += "d"+strconv.Itoa(defs_num)+": "
 			defs_num += 1
 		}
-		source += d + "\n\n"
+		source += indentCode(d, "    ") + "\n\n"
 	}
 
 	if print_linenums { source += "    " }
@@ -78,7 +82,7 @@ func (self *World) source_print(print_linenums bool) string {
 			source += "c"+strconv.Itoa(code_num)+": "
 			code_num += 1
 		}
-		source += "\t" + str.String() + ";\n"
+		source += "\t" + indentCode(str.String(), "\t") + ";\n"
 		switch c.(type) {
 		case *ast.AssignStmt:
 			for _, name := range c.(*ast.AssignStmt).Lhs {

--- a/main.go
+++ b/main.go
@@ -440,6 +440,7 @@ func main() {
 		}
 
 		w.exec = ""
+		cmd_args := strings.Trim(line[1:]," ")
 
 		switch line[0] {
 		case '?':
@@ -458,7 +459,7 @@ func main() {
 			fmt.Println("\tauto\tautosetup with some standard packages")
 			fmt.Println("For removal, -[dpc] is equivalent to -[dpc]<last index>")
 		case '+':
-			allpkgs := strings.Split(strings.Trim(line[1:]," "), " ")
+			allpkgs := strings.Split(cmd_args, " ")
 			fmt.Println("Importing: ")
 			for _, pkg_name := range allpkgs {
 				if pkg_name != "" {
@@ -486,7 +487,7 @@ func main() {
 			fmt.Println(w.source_print(true))
 		case ':':
 			line = line + ";"
-			tree, err := ParseStmtList(w.files, "go-repl", strings.Trim(line[1:]," "))
+			tree, err := ParseStmtList(w.files, "go-repl", cmd_args)
 			if err != nil {
 				fmt.Println("Parse error:", err)
 				continue


### PR DESCRIPTION
This is actually a fork from jessta/go-repl 2 years ago, in which he made changes to remove the dependency on the "container/vector" package and other things.

The rest of the commits are changes made to make it compatible with Go 1.0 and with additional features:
- Fix reliance on deprecated ParseStmtList and ParseDeclList. The redefinition hacks are partially taken from the go-eval project.
- Fix compiling error in the case that $GOBIN is not set (although it assume 64-bit amd64 architecture for now if that's the case).
- Added rollback for bad assignments or declarations.
- Added multiple argument functionality to import and removal
- Added line numbers to source inspection and allow removal of specific lines of code/declaration/package importing.
- Added many aliases to the set of special commands (see the help menu).
- Added "auto" for autosetup to include some basic packages and shortcuts for easy testing.
- Fix some bugs like resetting or declaration/code parsing order or committing only one command at a time.

About the removal, it's based on the newly added line numbers on the side. So if the source is this:

```
fmt> !

    package main
p0: import "fmt"

d0: var b = 9

    func noop(_ interface{}) {}

    func main() {
c0:     a := 1;
        noop(a);
c1:     fmt.Println(a);
c2:     b := 8;
        noop(b);
c3:     fmt.Println(b);
    }
```

Then "-c2" would remove the second to last line of code, and "-c0,1" would remove the first two lines of code. "-d" and "-d0" would both remove the global declaration of b, and "-p" and "-p0" would both remove the package "fmt" (although that would cause instability). This is the most complicated part of the set of changes made, done because at the time I really wanted to remove some line of code while testing.

Also, I made it note instability only for compilation reasons, so things like arr[1000] for a 5-int slice arr would give an error, but not be marked unstable. Of course, this can be tested with "run" to see.

I'm considering if I should add "insert code" functionality and fix the fact that you cannot execute (in the default case) multiple commands at once (only the last one is run). There is also the matter of testing, but I'll leave that for later. A further task is to also import personal files to just up and run them in the go-repl environment.

I believe it is worth putting some work into this interpreter/REPL, since igo and go-eval is still quite incomplete. When I tried them out, I found that it was annoying that they required using Go 1.2 and onward (which is annoying when the apt repository only has 1.0) and they cannot import. The need for importing is actually quite huge, as much of my testing is with functions defined in packages. I remember doing that many times for the Python interpreter, and I was quite annoyed with that igo didn't have that functionality implemented (which, frankly, makes it impossible to test out things because many implementations uses some package or another). Although go-repl is a bit hacky in the approach that it requires re-compiling everything for every command, it is ,much more useful for basic testing.

This version can be run from the following set of commands for now (in Ubuntu or Debian):
$ sudo apt-get install golang-go
$ sudo apt-get install golang
$ go version
go version go1
$ sudo go get github.com/eternia478/go-repl
$ export PATH=$PATH:/usr/lib/go/bin/
$ go-repl

It is suggest for users to include rlwrap, to make typing easier (up and down for history, left and right to edit the input in the middle). A simple apt-get install rlwrap would do.
